### PR TITLE
Fix switching between dart.io and dart.html websockets

### DIFF
--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -26,19 +26,25 @@ class Socket extends Emitter {
   static const int CLOSING = 2;
   static const int CLOSED = 3;
 
-  Socket._internal(this._socket, {this.authToken, this.strategy, this.listener}) {
+  Socket._internal(this._socket,
+      {this.authToken, this.strategy, this.listener}) {
     this._socket = _socket;
-    if (globalSocketPlatform == IoSocketPlatform) {
+    if (globalSocketPlatform is IoSocketPlatform) {
       _socket.listen(handleMessage).onDone(onSocketDone);
       onSocketOpened();
     } else {
-      _socket..onOpen.listen(onSocketOpened)..onClose.listen(onSocketDone)..onMessage.listen(handleMessage);
+      _socket
+        ..onOpen.listen(onSocketOpened)
+        ..onClose.listen(onSocketDone)
+        ..onMessage.listen(handleMessage);
     }
   }
 
   static Future<Socket> connect(String url,
-      {String authToken, ReconnectStrategy strategy, BasicListener listener}) async {
-    if (globalSocketPlatform == IoSocketPlatform){
+      {String authToken,
+      ReconnectStrategy strategy,
+      BasicListener listener}) async {
+    if (globalSocketPlatform is IoSocketPlatform) {
       var socket = await globalSocketPlatform.webSocket(url);
       return new Socket._internal(
         socket,
@@ -47,10 +53,11 @@ class Socket extends Emitter {
         listener: listener,
       );
     } else {
-        var _htmlsocket = globalSocketPlatform.webSocket(url);
-        var _socket = new Socket._internal(_htmlsocket, authToken: authToken, strategy: strategy, listener: listener);
-        await whenTrue(_socket._socket.onOpen);
-        return _socket;
+      var _htmlsocket = globalSocketPlatform.webSocket(url);
+      var _socket = new Socket._internal(_htmlsocket,
+          authToken: authToken, strategy: strategy, listener: listener);
+      await whenTrue(_socket._socket.onOpen);
+      return _socket;
     }
   }
 
@@ -64,8 +71,8 @@ class Socket extends Emitter {
     // stream exited without a true value, maybe return an exception.
   }
 
-  sendOrAdd([json]){
-    if (globalSocketPlatform == IoSocketPlatform) {
+  sendOrAdd([json]) {
+    if (globalSocketPlatform is IoSocketPlatform) {
       _socket.add(json);
     } else {
       _socket.send(json);
@@ -115,10 +122,10 @@ class Socket extends Emitter {
 
   void handleMessage([dynamic messageEvent]) {
     String message;
-    if (globalSocketPlatform != IoSocketPlatform) {
-      message = messageEvent.data;
-    } else {
+    if (globalSocketPlatform is IoSocketPlatform) {
       message = messageEvent;
+    } else {
+      message = messageEvent.data;
     }
     if (message == "#1") {
       sendOrAdd('#2');

--- a/lib/src/socket_platform_io.dart
+++ b/lib/src/socket_platform_io.dart
@@ -3,10 +3,11 @@ import 'dart:io';
 import 'socket_platform_interface.dart' as socketinterface;
 
 const IoSocketPlatform ioSocketPlatform = const IoSocketPlatform();
+
 class IoSocketPlatform extends socketinterface.IoSocketPlatform {
   const IoSocketPlatform();
 
-  Function webSocket([url]) => WebSocket.connect;
+  Future<WebSocket> webSocket([url]) => WebSocket.connect(url);
 }
 
 const socketinterface.SocketPlatform RuntimeSocketPlatform = ioSocketPlatform;


### PR DESCRIPTION
The changes made to socketcluster_client to support web platform broke mobile, as the checks were implemented incorrectly.

* Need to use `is` to test runtime types, `==` and `!=` do not work.
* `IoSocketPlatform.webSocket` was never actually calling connect
* Rest of PR is a few formatting tweaks as I use the same dartfmt configuration as the Flutter project.

Closes #11